### PR TITLE
refactor(TrovesManager): change troves entrypoint's signature (SL-65)

### DIFF
--- a/contracts/TroveManager.aes
+++ b/contracts/TroveManager.aes
@@ -328,7 +328,7 @@ contract TroveManager =
     // DATA GETTERS
     //------------------------------------------------------------------------------
 
-    entrypoint troves() = state.troves
+    entrypoint troves(owner: address): option(trove) = Map.lookup(owner,state.troves)
 
     entrypoint total_stakes() = state.total_stakes
 

--- a/deployment/deploy.js
+++ b/deployment/deploy.js
@@ -98,7 +98,7 @@ const deploy = async ( secretKey, network, compiler ) => {
             ),
         ]
     //for ( const dep of deployments ) { await dep() }
-    await deployments[17]()
+    await deployments[4]()
 }
 
 module.exports = {

--- a/test/borrower-operations.test.js
+++ b/test/borrower-operations.test.js
@@ -252,7 +252,6 @@ describe( 'Borrower Operations', () => {
             await contracts.borrowerOperations.withdraw_coll( testHelper.dec( 1, 'ae' ), aliceAddress, aliceAddress, { onAccount: alice } )
 
             // Check 1 ether remaining
-            const alice_Trove_After = ( await contracts.troveManager.troves() ).get( aliceAddress )
             const aliceCollAfter = await getTroveEntireColl( aliceAddress )
 
             assert.isTrue( aliceCollAfter == aliceCollBefore - testHelper.dec( 1, 'ae' ) )
@@ -281,7 +280,7 @@ describe( 'Borrower Operations', () => {
             const aliceColl = await getTroveEntireColl( aliceAddress )
             assert.isTrue( aliceColl > 0 )
             
-            const alice_Trove_Before = ( await contracts.troveManager.troves() ).get( aliceAddress )
+            const alice_Trove_Before = await contracts.troveManager.troves( aliceAddress )
             const alice_Stake_Before = BigInt( alice_Trove_Before.stake )
             const totalStakes_Before = BigInt( await contracts.troveManager.total_stakes() )
 
@@ -292,7 +291,7 @@ describe( 'Borrower Operations', () => {
             await contracts.borrowerOperations.withdraw_coll( testHelper.dec( 1, 'ae' ), aliceAddress, aliceAddress, { onAccount: alice } )
 
             // Check stake and total stakes get updated
-            const alice_Trove_After = ( await contracts.troveManager.troves() ).get( aliceAddress )
+            const alice_Trove_After = await contracts.troveManager.troves( aliceAddress )
             const alice_Stake_After = BigInt( alice_Trove_After.stake )
             const totalStakes_After = BigInt( await contracts.troveManager.total_stakes() )
 
@@ -744,7 +743,7 @@ describe( 'Borrower Operations', () => {
             const emittedFee = testHelper.getAEUSDFeeFromAEUSDBorrowingEvent( withdrawalTx )
             assert.isTrue( emittedFee > 0 )
 
-            const newDebt = ( await contracts.troveManager.troves() ).get( DAddress ).debt
+            const newDebt = ( await contracts.troveManager.troves( DAddress ) ).debt
 
             // Check debt on Trove struct equals initial debt + withdrawal + emitted fee
             testHelper.assertIsApproximatelyEqual( newDebt, D_debtBefore + withdrawal_D + emittedFee, 10000 )
@@ -1583,7 +1582,7 @@ describe( 'Borrower Operations', () => {
             const emittedFee = BigInt( testHelper.getAEUSDFeeFromAEUSDBorrowingEvent( openTroveTx ) )
             assert.isTrue( BigInt( emittedFee ) > 0 )
 
-            const newDebt = ( await contracts.troveManager.troves() ).get( DAddress ).debt
+            const newDebt = ( await contracts.troveManager.troves( DAddress ) ).debt
 
             // Check debt on Trove struct equals drawn debt plus emitted fee
             testHelper.assertIsApproximatelyEqual( newDebt, D_LUSDRequest + emittedFee + LUSD_GAS_COMPENSATION, 100000 )

--- a/test/sorted-troves.test.js
+++ b/test/sorted-troves.test.js
@@ -40,6 +40,7 @@ describe( 'SortedTroves Tests', () => {
         let contracts
         let LQTYContracts
         const openTrove = async ( params ) => testHelper.openTrove( contracts, params )
+        const getTrove = ( address ) => contracts.troveManager.troves( address )
 
         utils.beforeEachWithSnapshot( 'deploy contract', async () => {
             const { deployLiquityCore, deployLQTYContracts } = await setupDeployment()
@@ -67,12 +68,10 @@ describe( 'SortedTroves Tests', () => {
             await openTrove( { ICR: dec( 20, 18 ), extraParams: { onAccount: bob } } )
             await openTrove( { ICR: dec( 2000, 18 ), extraParams: { onAccount: carol } } )
 
-            const troves = await contracts.troveManager.troves()
-
             // Confirm trove statuses became active
-            expect( troves.get( aliceAddress ).status ).to.have.all.keys( 'Active' )
-            expect( troves.get( bobAddress ).status ).to.have.all.keys( 'Active' )
-            expect( troves.get( carolAddress ).status ).to.have.all.keys( 'Active' )
+            expect( ( await getTrove( aliceAddress ) ).status ).to.have.all.keys( 'Active' )
+            expect( ( await getTrove( bobAddress ) ).status ).to.have.all.keys( 'Active' )
+            expect( ( await getTrove( carolAddress ) ).status ).to.have.all.keys( 'Active' )
 
             // Check sorted list contains troves
             assert.isTrue( await contracts.sortedTroves.contains( aliceAddress ) )
@@ -87,11 +86,10 @@ describe( 'SortedTroves Tests', () => {
             await openTrove( { ICR: dec( 2000, 18 ), extraParams: { onAccount: carol } } )
 
             // Confirm troves have non-existent status
-            const troves = await contracts.troveManager.troves()
 
             // Confirm troves have non-existent status
-            expect( troves.get( denisAddress ) ).equal( undefined )
-            expect( troves.get( erinAddress ) ).equal( undefined )
+            expect( ( await getTrove( denisAddress ) ) ).equal( undefined )
+            expect( ( await getTrove( erinAddress ) ) ).equal( undefined )
 
             // Check sorted list do not contain troves
             assert.isFalse( await contracts.sortedTroves.contains( denisAddress ) )
@@ -116,11 +114,10 @@ describe( 'SortedTroves Tests', () => {
             await contracts.borrowerOperations.close_trove( { onAccount: carol } )
 
             // Confirm trove statuses became closed
-            const troves = await contracts.troveManager.troves()
 
-            expect( troves.get( aliceAddress ).status ).to.have.all.keys( 'ClosedByOwner' )
-            expect( troves.get( bobAddress ).status ).to.have.all.keys( 'ClosedByOwner' )
-            expect( troves.get( carolAddress ).status ).to.have.all.keys( 'ClosedByOwner' )
+            expect( ( await getTrove( aliceAddress ) ).status ).to.have.all.keys( 'ClosedByOwner' )
+            expect( ( await getTrove( bobAddress ) ).status ).to.have.all.keys( 'ClosedByOwner' )
+            expect( ( await getTrove( carolAddress ) ).status ).to.have.all.keys( 'ClosedByOwner' )
 
             // Check sorted list does not contain troves
             assert.isFalse( await contracts.sortedTroves.contains( aliceAddress ) )
@@ -147,20 +144,18 @@ describe( 'SortedTroves Tests', () => {
             await contracts.borrowerOperations.close_trove( { onAccount: carol } )
 
             // Confirm trove statuses became closed
-            let troves = await contracts.troveManager.troves()
-            expect( troves.get( aliceAddress ).status ).to.have.all.keys( 'ClosedByOwner' )
-            expect( troves.get( bobAddress ).status ).to.have.all.keys( 'ClosedByOwner' )
-            expect( troves.get( carolAddress ).status ).to.have.all.keys( 'ClosedByOwner' )
+            expect( ( await getTrove( aliceAddress ) ).status ).to.have.all.keys( 'ClosedByOwner' )
+            expect( ( await getTrove( bobAddress ) ).status ).to.have.all.keys( 'ClosedByOwner' )
+            expect( ( await getTrove( carolAddress ) ).status ).to.have.all.keys( 'ClosedByOwner' )
 
             await openTrove( { ICR: dec( 1000, 16 ), extraParams: { onAccount: alice } } )
             await openTrove( { ICR: dec( 2000, 18 ), extraParams: { onAccount: bob } } )
             await openTrove( { ICR: dec( 3000, 18 ), extraParams: { onAccount: carol } } )
 
             // Confirm trove statuses became open again
-            troves = await contracts.troveManager.troves()
-            expect( troves.get( aliceAddress ).status ).to.have.all.keys( 'Active' )
-            expect( troves.get( bobAddress ).status ).to.have.all.keys( 'Active' )
-            expect( troves.get( carolAddress ).status ).to.have.all.keys( 'Active' )
+            expect( ( await getTrove( aliceAddress ) ).status ).to.have.all.keys( 'Active' )
+            expect( ( await getTrove( bobAddress ) ).status ).to.have.all.keys( 'Active' )
+            expect( ( await getTrove( carolAddress ) ).status ).to.have.all.keys( 'Active' )
 
             // Check sorted list does  contain troves
             assert.isTrue( await contracts.sortedTroves.contains( aliceAddress ) )


### PR DESCRIPTION
The `troves` entrypoint returns the whole structure of stored troves. It’s inefficient, so It should be changed to return only the trove belonging to a certain address
The modification involves changing all related calls from other contracts (if any), and also the tests which involve assumptions on this entrypoint